### PR TITLE
MOBILE-11 fix url encoding bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ViSearch is an API that provides accurate, reliable and scalable image search. V
 
 The ViSearch iOS SDK is an open source software to provide easy integration of ViSearch Search API with your iOS applications. It provides three search methods based on the ViSearch Search API - pre-indexed search, color search and upload search. For source code and references, please visit the [Github Repository](https://github.com/visenze/visearch-sdk-ios).
 
->Current stable version: 1.0.5
+>Current stable version: 1.0.6
 
 >Supported iOS version: iOS 6.x and higher 
 
@@ -70,7 +70,7 @@ Edit the Podfile as follow:
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '7.0' 
 ...
-pod 'ViSearch', '~>1.0.5'
+pod 'ViSearch', '~>1.0.6'
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ When performing upload search, you may notice the increased search latency with 
 To reduce upload search latency, by default the uploadSearch method makes a copy of your image file and resizes the copy to 512x512 pixels if one of the original dimensions exceed 512 pixels. This is the optimized size to lower search latency while not sacrificing search accuracy for general use cases:
 
 ```objectivec
-// by default, the max width of the image is set to 512px, quality is 1.0
+// by default, the max width of the image is set to 512px, quality is 0.97
 UploadSearchParams *uploadSearchParams = [[UploadSearchParams alloc] init];
 // or you can explicitly set a param's settings
 uploadSearchParams.settings = [ImageSettings defaultSettings];
@@ -227,10 +227,10 @@ uploadSearchParams.settings = [ImageSettings defaultSettings];
 If your image contains fine details such as textile patterns and textures, you can use an image with larger size for search to get better search result:
 
 ```objectivec
-// by default, the max width of the image is set to 512px, quality is 1.0
+// by default, the max width of the image is set to 512px, quality is 0.97
 UploadSearchParams *uploadSearchParams = [[UploadSearchParams alloc] init];
 // set the image with high quality settings. 
-// Max width is 1024px, and the quality is 0.9. Note: Quality with 1.0 take hugespace
+// Max width is 1024px, and the quality is 0.985.
 uploadSearchParams.settings = [ImageSettings highqualitySettings];
 ```
 
@@ -332,13 +332,13 @@ UploadSearchParams *uploadSearchParams = [[UploadSearchParams alloc] init];
 
 // the type of "count" on db schema is int, 
 // so we can specify the value range, or do a value match
-[uploadSearchParams.fq setObject:@"count" forKey:@"0, 199"];
-[uploadSearchParams.fq setObject:@"count" forKey:@"199"];
+[uploadSearchParams.fq setObject:@"0, 199" forKey:@"count"];
+[uploadSearchParams.fq setObject:@"199" forKey:@"count"];
 
 // the type of "price" on db schema is float, 
 // so we can specify the value range, or do a value match
-[uploadSearchParams.fq setObject:@"price" forKey:@"0.0, 199.0"];
-[uploadSearchParams.fq setObject:@"price" forKey:@"15.0"];
+[uploadSearchParams.fq setObject:@"0.0, 199.0" forKey:@"price"];
+[uploadSearchParams.fq setObject:@"15.0" forKey:@"price"];
 
 // the type of "description" on db schema is string, so we can do a string match. 
 [uploadSearchParams.fq setObject:@"description" forKey:@"wooden"];

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ViSearch is an API that provides accurate, reliable and scalable image search. V
 
 The ViSearch iOS SDK is an open source software to provide easy integration of ViSearch Search API with your iOS applications. It provides three search methods based on the ViSearch Search API - pre-indexed search, color search and upload search. For source code and references, please visit the [Github Repository](https://github.com/visenze/visearch-sdk-ios).
 
->Current stable version: 1.0.4
+>Current stable version: 1.0.5
 
 >Supported iOS version: iOS 6.x and higher 
 
@@ -70,7 +70,7 @@ Edit the Podfile as follow:
 source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '7.0' 
 ...
-pod 'ViSearch', '~>1.0.4'
+pod 'ViSearch', '~>1.0.5'
 ...
 ```
 
@@ -230,14 +230,14 @@ If your image contains fine details such as textile patterns and textures, you c
 // by default, the max width of the image is set to 512px, quality is 0.97
 UploadSearchParams *uploadSearchParams = [[UploadSearchParams alloc] init];
 // set the image with high quality settings. 
-// Max width is 1024px, and the quality is 0.985.
+// Max width is 1024px, and the quality is 0.985. Note: Quality with 1.0 take hugespace
 uploadSearchParams.settings = [ImageSettings highqualitySettings];
 ```
 
 Or, provide the customized resize settings. To make efficient use the of the memory and network bandwidth of mobile device, the maximum size is set at 1024 x 1024. Any image exceeds the limit will be resized to the limit:
 
 ```objectivec
-//resize the image to 800 by 800 area using jpeg 1.0 quality
+//resize the image to 800 by 800 area using jpeg 0.9 quality
 uploadSearchParams.settings = [[ImageSettings alloc] 
 	initWithSize:CGSizeMake(800, 800) Quality:0.9];
 ```

--- a/ViSearch.podspec
+++ b/ViSearch.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "ViSearch"
-  s.version          = "1.0.5"
+  s.version          = "1.0.6"
   s.summary          = "A Visual Search API solution."
   s.description      = <<-DESC
                         ViSearch is a Visual Recognition Service API developed by ViSenze Pte. Ltd.

--- a/ViSearch.podspec
+++ b/ViSearch.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "ViSearch"
-  s.version          = "1.0.3"
+  s.version          = "1.0.5"
   s.summary          = "A Visual Search API solution."
   s.description      = <<-DESC
                         ViSearch is a Visual Recognition Service API developed by ViSenze Pte. Ltd.

--- a/ViSearchSDK/ViSearchAPISource/ViSearchHandler.m
+++ b/ViSearchSDK/ViSearchAPISource/ViSearchHandler.m
@@ -67,8 +67,9 @@
                 for (NSString* value in [params objectForKey:key]) {
                     [urlString appendFormat:@"&%@=%@", key, value];
                 }
+            } else {
+                [urlString appendFormat:@"&%@=%@", key, [params objectForKey:key]];
             }
-            [urlString appendFormat:@"&%@=%@", key, [params objectForKey:key]];
         }
     }
     return [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];

--- a/ViSearchSDK/ViSearchAPISource/ViSearchHandler.m
+++ b/ViSearchSDK/ViSearchAPISource/ViSearchHandler.m
@@ -58,21 +58,30 @@
     return result;
 }
 
+- (NSString *)urlEncodeValue:(NSString *)str
+{
+    NSString *result = (NSString *)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(kCFAllocatorDefault, (CFStringRef)str, NULL, CFSTR(":/?#[]@!$&’()*+,;="), kCFStringEncodingUTF8));
+    return result;
+}
+
 - (NSString*)generateRequestUrlPrefixWithParams:(NSDictionary*)params {
     NSMutableString *urlString = [NSMutableString stringWithFormat:@"%@/%@?", [self.delegate getHost], self.searchType];
     
     if (params != nil) {
         for (NSString* key in params.allKeys) {
+            NSString* encodeKey = [self urlEncodeValue:key];
             if([[params objectForKey:key] isKindOfClass:[NSArray class]]){
                 for (NSString* value in [params objectForKey:key]) {
-                    [urlString appendFormat:@"&%@=%@", key, value];
+                    NSString* encodeValue = [self urlEncodeValue:value];
+                    [urlString appendFormat:@"&%@=%@", encodeKey, encodeValue];
                 }
             } else {
-                [urlString appendFormat:@"&%@=%@", key, [params objectForKey:key]];
+                NSString* encodeParam =[self urlEncodeValue:[params objectForKey:key]];
+                [urlString appendFormat:@"&%@=%@", encodeKey, encodeParam];
             }
         }
     }
-    return [urlString stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    return urlString;
 }
 
 - (NSString *)getAuthParams {


### PR DESCRIPTION
reviewer: @jasonpeng 
fix the url encoding by only encode each params, but not the whole url. update the version number to 1.0.6, revised doc accordingly