### PR TITLE
DR-1342 add init ViSearch client with app key

### DIFF
--- a/NewExample/ViSearchExample/DemoApp/Applications+CoreDataProperties.h
+++ b/NewExample/ViSearchExample/DemoApp/Applications+CoreDataProperties.h
@@ -15,6 +15,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface Applications (CoreDataProperties)
 
+
+@property (nullable, nonatomic, retain) NSString *app_key;
+
 @property (nullable, nonatomic, retain) NSString *access_key;
 @property (nullable, nonatomic, retain) NSNumber *account_id;
 @property (nullable, nonatomic, retain) NSString *account_name;

--- a/NewExample/ViSearchExample/DemoApp/Applications+CoreDataProperties.m
+++ b/NewExample/ViSearchExample/DemoApp/Applications+CoreDataProperties.m
@@ -21,5 +21,6 @@
 @dynamic is_in_use;
 @dynamic secret_key;
 @dynamic is_new;
+@dynamic app_key;
 
 @end

--- a/NewExample/ViSearchExample/DemoApp/CoreDataModel.m
+++ b/NewExample/ViSearchExample/DemoApp/CoreDataModel.m
@@ -45,11 +45,17 @@
 - (void) insertApplication:(NSDictionary*)json {
     if (json) {
         NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:ENTITY_NAME];
-        [request setPredicate:[NSPredicate predicateWithFormat:@"access_key = %@ and secret_key = %@", [json objectForKey:@"access_key"],[json objectForKey:@"secret_key"]]];
+        
+//        [request setPredicate:[NSPredicate predicateWithFormat:@"access_key = %@ and secret_key = %@", [json objectForKey:@"access_key"],[json objectForKey:@"secret_key"]]];
+        
+        [request setPredicate:[NSPredicate predicateWithFormat:@"app_key = %@", [json objectForKey:@"app_key"] ]];
+        
+        
         [request setFetchLimit:1];
         
         NSError *error;
         NSUInteger count = [self.managedObjectContext countForFetchRequest:request error:&error];
+        
         
         if (count == NSNotFound) { // some error occurred
             NSLog(@"Has error: %@", [error localizedDescription]);
@@ -65,6 +71,10 @@
             app.app_name = [json objectForKey:@"app_name"];
             app.secret_key = [json objectForKey:@"secret_key"];
             
+            app.app_key = [json objectForKey:@"app_key"];
+            
+            NSLog(@"app_key : %@" , app.app_key);
+            
             [self updateUseStatus:[self getApplicationInUse] withBool:NO];
             [self updateUseStatus:app withBool:YES];
             
@@ -78,7 +88,10 @@
 - (void) updateUseStatus:(Applications*)app withBool:(BOOL)val{
     if (app) {
         NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:ENTITY_NAME];
-        [request setPredicate:[NSPredicate predicateWithFormat:@"access_key = %@ and secret_key = %@", app.access_key, app.secret_key]];
+//        [request setPredicate:[NSPredicate predicateWithFormat:@"access_key = %@ and secret_key = %@", app.access_key, app.secret_key]];
+        
+        [request setPredicate:[NSPredicate predicateWithFormat:@"app_key = %@", app.app_key ]];
+        
         
         NSError *error;
         fetchedObjects = [self.managedObjectContext executeFetchRequest:request error:&error];

--- a/NewExample/ViSearchExample/DemoApp/DemoApp.xcdatamodeld/DemoApp.xcdatamodel/contents
+++ b/NewExample/ViSearchExample/DemoApp/DemoApp.xcdatamodeld/DemoApp.xcdatamodel/contents
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="9057" systemVersion="14F1021" minimumToolsVersion="Automatic">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="11759" systemVersion="15G1212" minimumToolsVersion="Xcode 7.3" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
     <entity name="Applications" representedClassName="Applications" syncable="YES">
         <attribute name="access_key" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="account_id" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="account_id" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="account_name" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="app_id" optional="YES" attributeType="Integer 32" defaultValueString="0" syncable="YES"/>
+        <attribute name="app_id" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="app_key" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="app_name" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="is_in_use" optional="YES" attributeType="Boolean" defaultValueString="NO" syncable="YES"/>
-        <attribute name="is_new" optional="YES" attributeType="Boolean" defaultValueString="YES" syncable="YES"/>
+        <attribute name="is_in_use" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="is_new" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="secret_key" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
     <elements>
-        <element name="Applications" positionX="-63" positionY="-18" width="128" height="165"/>
+        <element name="Applications" positionX="-63" positionY="-18" width="128" height="180"/>
     </elements>
 </model>

--- a/NewExample/ViSearchExample/DemoApp/GeneralServices.m
+++ b/NewExample/ViSearchExample/DemoApp/GeneralServices.m
@@ -214,14 +214,18 @@
     } failure:^(NSInteger statusCode, ViSearchResult *data, NSError *error) {
         completionBlock(NO, data);
     }];
+    
+   
 }
 
 - (void)trackClickWithImgName:(NSString*)imageName
              reqId:(NSString*) reqId
 {
-    TrackParams* params = [TrackParams createWithAccessKey:[ViSearchAPI defaultClient].accessKey reqId:reqId andAction:@"click"];
+    TrackParams* params = [TrackParams createWithReqId:reqId andAction:@"click" ];
     [params withImName:imageName];
-    [[ViSearchAPI defaultClient] track:params completion:nil];
+    [[ViSearchAPI defaultClient] track:params completion:^( BOOL complete){
+        NSLog(@"track done");
+    }];
 }
 
 @end

--- a/NewExample/ViSearchExample/DemoApp/HomeViewController.m
+++ b/NewExample/ViSearchExample/DemoApp/HomeViewController.m
@@ -29,7 +29,7 @@
     NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
     
     // new way of authenticate. only need app key
-    [dict setValue:@"YOUR_ACCESS_KEY" forKey:@"app_key"];
+    [dict setValue:@"YOUR_APP_KEY" forKey:@"app_key"];
     
     // old way of authentication which need access and secret key
 //    [dict setValue:@"YOUR_ACCESS_KEY" forKey:@"access_key"];

--- a/NewExample/ViSearchExample/DemoApp/HomeViewController.m
+++ b/NewExample/ViSearchExample/DemoApp/HomeViewController.m
@@ -27,8 +27,13 @@
     
     //TODO: insert your own application keys
     NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
-    [dict setValue:@"YOUR_ACCESS_KEY" forKey:@"access_key"];
-    [dict setValue:@"YOUR_SECRET_KEY" forKey:@"secret_key"];
+    
+    // new way of authenticate. only need app key
+    [dict setValue:@"YOUR_ACCESS_KEY" forKey:@"app_key"];
+    
+    // old way of authentication which need access and secret key
+//    [dict setValue:@"YOUR_ACCESS_KEY" forKey:@"access_key"];
+//    [dict setValue:@"YOUR_SECRET_KEY" forKey:@"secret_key"];
     
     [[CoreDataModel sharedInstance] insertApplication:dict];
 }

--- a/NewExample/ViSearchExample/DemoApp/Info.plist
+++ b/NewExample/ViSearchExample/DemoApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.1</string>
+	<string>1.2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/NewExample/ViSearchExample/DemoApp/PreviewViewController.m
+++ b/NewExample/ViSearchExample/DemoApp/PreviewViewController.m
@@ -61,7 +61,13 @@
 
 - (void) initApplication {
     self.applicationInUse = [[CoreDataModel sharedInstance] getApplicationInUse];
-    [ViSearchAPI setupAccessKey:self.applicationInUse.access_key andSecretKey:self.applicationInUse.secret_key];
+    
+    // old way of init with both access and secret
+//    [ViSearchAPI setupAccessKey:self.applicationInUse.access_key andSecretKey:self.applicationInUse.secret_key];
+    
+    // new way of init with only app key
+    [ViSearchAPI setupAppKey:self.applicationInUse.app_key];
+    
 }
 
 - (void)initBackgroundView {

--- a/NewExample/ViSearchExample/DemoApp/ResultViewController.m
+++ b/NewExample/ViSearchExample/DemoApp/ResultViewController.m
@@ -98,7 +98,11 @@ typedef enum {
 - (void) initValues {
     self.generalService = [GeneralServices sharedInstance];
     self.imageCache = [[NSMutableDictionary alloc] init];
-    self.productType = [self.searchResults.productTypes objectAtIndex:0];
+    
+    if (self.searchResults.productTypes.count > 0)
+        self.productType = [self.searchResults.productTypes objectAtIndex:0];
+   
+    
     self.image = self.originalImage;
     self.loadedCell = [[NSMutableSet alloc] init];
     

--- a/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPI.h
+++ b/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPI.h
@@ -13,6 +13,7 @@
 @interface ViSearchAPI : NSObject
 
 + (void)setupAccessKey:(NSString*) accessKey andSecretKey:(NSString*)secretKey;
++ (void)setupAppKey:(NSString *)appKey;
 + (ViSearchClient *) defaultClient;
 
 @end

--- a/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPI.m
+++ b/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPI.m
@@ -16,6 +16,10 @@
     [ViSearchClient sharedInstance].secretKey = secretKey;
 }
 
++ (void)setupAppKey:(NSString *)appKey {
+    [ViSearchClient sharedInstance].accessKey = appKey ;
+}
+
 + (ViSearchClient *)defaultClient {
     return [ViSearchClient sharedInstance];
 }

--- a/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/TrackParams.h
+++ b/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/TrackParams.h
@@ -17,7 +17,7 @@
 @property (nonatomic, readonly) NSString * action;
 @property (nonatomic) NSString * imName;
 @property (nonatomic, readonly) NSString * reqId;
-@property (nonatomic, readonly) NSString * cid; // set to access key
+@property (nonatomic) NSString * cid; // set to access key
 @property (nonatomic) NSString * cuid;
 
 
@@ -27,6 +27,9 @@
 
 + (TrackParams *)createWithCID:(NSString *)cid ReqId:(NSString *)reqId andAction:(NSString *)action __deprecated_msg("use createWithAccessKey:accessKey:reqId:andAction method instead");
 + (TrackParams *)createWithAccessKey:(NSString *)accessKey reqId:(NSString *)reqId andAction:(NSString *)action;
++ (TrackParams *)createWithAppKey:(NSString *)appKey reqId:(NSString *)reqId andAction:(NSString *)action;
++ (TrackParams *)createWithReqId:(NSString *)reqId andAction:(NSString *)action;
+
 
 @end
 

--- a/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/TrackParams.m
+++ b/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/TrackParams.m
@@ -34,6 +34,16 @@
     return self;
 }
 
+- (TrackParams *)initWithReqId:(NSString *)reqId andAction:(NSString *)action {
+    self = [super init];
+    if (self) {
+        _reqId = reqId;
+        _action = action;
+    }
+    
+    return self;
+}
+
 
 - (TrackParams *)withImName:(NSString *)imName {
     _imName = imName;
@@ -60,6 +70,37 @@
     }
 
     return [[TrackParams new] initWithCID:accessKey ReqId:reqId andAction:action];
+}
+
++ (TrackParams *)createWithAppKey:(NSString *)appKey reqId:(NSString *)reqId andAction:(NSString *)action
+{
+    if( appKey == nil || [appKey length] == 0 ){
+        [NSException raise:NSInvalidArgumentException format:@"*** -[%@ %@]: Missing parameter: appKey",  NSStringFromClass([self class]), NSStringFromSelector(_cmd)] ;
+    }
+    
+    if( reqId == nil || [reqId length] == 0 ){
+        [NSException raise:NSInvalidArgumentException format:@"*** -[%@ %@]: Missing parameter: reqId",  NSStringFromClass([self class]), NSStringFromSelector(_cmd)] ;
+    }
+    
+    if( action == nil || [action length] == 0 ){
+        [NSException raise:NSInvalidArgumentException format:@"*** -[%@ %@]: Missing parameter: action",  NSStringFromClass([self class]), NSStringFromSelector(_cmd)] ;
+    }
+    
+    return [[TrackParams new] initWithCID:appKey ReqId:reqId andAction:action];
+}
+
+// accesskey is now retrieve directly from visearch client
++ (TrackParams *)createWithReqId:(NSString *)reqId andAction:(NSString *)action
+{
+    if( reqId == nil || [reqId length] == 0 ){
+        [NSException raise:NSInvalidArgumentException format:@"*** -[%@ %@]: Missing parameter: reqId",  NSStringFromClass([self class]), NSStringFromSelector(_cmd)] ;
+    }
+    
+    if( action == nil || [action length] == 0 ){
+        [NSException raise:NSInvalidArgumentException format:@"*** -[%@ %@]: Missing parameter: action",  NSStringFromClass([self class]), NSStringFromSelector(_cmd)] ;
+    }
+    
+    return [[TrackParams new] initWithReqId:reqId andAction:action];
 }
 
 - (NSDictionary *)toDict {

--- a/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/ViSearchBasicHandler.m
+++ b/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/ViSearchBasicHandler.m
@@ -22,10 +22,25 @@
     else
         [request addValue:kVisenzeUserAgentValue forHTTPHeaderField:kVisenzeUserAgentHeader];
     
-    NSString *urlString = [self generateRequestUrlPrefixWithParams: params.toDict];
+    
+    
+    NSMutableDictionary* paramDict = [[params toDict] mutableCopy];
+    
+    // old way of authentication
+    if(self.delegate!=nil && [self.delegate getAppKey] == nil)
+    {
+        [request addValue:self.getAuthParams forHTTPHeaderField:@"Authorization"];
+    }
+    else {
+        // add in the access key
+        paramDict[@"access_key"] = [self.delegate getAppKey];
+    }
+    
+    NSString *urlString = [self generateRequestUrlPrefixWithParams: paramDict];
+    
     [request setURL: [NSURL URLWithString:urlString]];
-    [request addValue:self.getAuthParams forHTTPHeaderField:@"Authorization"];
-
+    
+    
     NSOperationQueue *queue = [self.delegate getOperationQ];
     
     [NSURLConnection sendAsynchronousRequest:request queue:queue

--- a/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/ViSearchClient.h
+++ b/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/ViSearchClient.h
@@ -19,6 +19,7 @@
 
 @property NSString *accessKey;
 @property NSString *secretKey;
+@property BOOL isAppKeyEnabled;
 @property(readonly) NSString *host;
 @property (nonatomic, assign) int timeoutInterval; // add time out interval for search client, default to 10s
 
@@ -27,6 +28,8 @@
 + (ViSearchClient *)sharedInstance;
 
 - (ViSearchClient *)initWithBaseUrl:(NSString *)baseUrl accessKey:(NSString *)accessKey secretKey:(NSString *) secretKey;
+- (ViSearchClient *)initWithBaseUrl:(NSString *)baseUrl appKey:(NSString *)appKey ;
+
 
 - (void)searchWithImageId:(SearchParams *)params
                   success:(void (^)(NSInteger statusCode, ViSearchResult *data, NSError *error)) success

--- a/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/ViSearchClient.m
+++ b/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/ViSearchClient.m
@@ -31,6 +31,7 @@
         sharedInstance = [[ViSearchClient alloc] init];
         sharedInstance.accessKey = @"";
         sharedInstance.secretKey = @"";
+        sharedInstance.isAppKeyEnabled = YES;
         sharedInstance.timeoutInterval = 10;
         sharedInstance.userAgent = kVisenzeUserAgentValue ;
     });
@@ -43,6 +44,21 @@
         self.host = baseUrl;
         self.accessKey = accessKey;
         self.secretKey = secretKey;
+        self.timeoutInterval = 10;
+        self.operationQ = [NSOperationQueue new];
+        self.userAgent = kVisenzeUserAgentValue ;
+        self.isAppKeyEnabled = NO;
+    }
+    
+    return self;
+}
+
+- (ViSearchClient *)initWithBaseUrl:(NSString *)baseUrl appKey:(NSString *)appKey {
+    if (self = [super init]) {
+        self.host = baseUrl;
+        self.accessKey = appKey;
+        self.secretKey = @"";
+        self.isAppKeyEnabled = YES;
         self.timeoutInterval = 10;
         self.operationQ = [NSOperationQueue new];
         self.userAgent = kVisenzeUserAgentValue ;
@@ -199,6 +215,7 @@
     handler.searchType = @"__aq.gif";
     handler.delegate = self;
     handler.userAgent = self.userAgent;
+    trackParams.cid = self.accessKey;
     
     [handler handleWithParams:trackParams completion:completion];
 }
@@ -206,6 +223,13 @@
 #pragma mark ViNetworkDelegate
 
 - (NSString *)getAccessKey {
+    return self.accessKey;
+}
+
+- (NSString *)getAppKey {
+    if (!self.isAppKeyEnabled)
+        return nil;
+    
     return self.accessKey;
 }
 

--- a/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/ViSearchHandler.h
+++ b/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/ViSearchHandler.h
@@ -14,6 +14,7 @@
 
 - (NSString *)getAccessKey;
 - (NSString *)getSecretKey;
+- (NSString *)getAppKey;
 - (NSString *)getHost;
 - (NSOperationQueue *)getOperationQ;
 

--- a/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/ViSearchImageUploadHandler.m
+++ b/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/ViSearchImageUploadHandler.m
@@ -28,7 +28,23 @@
     [request setHTTPMethod:@"POST"];
     [request setTimeoutInterval:self.timeoutInterval];
    
-    [request addValue:self.getAuthParams forHTTPHeaderField:@"Authorization"];
+    // old way of authentication
+    NSMutableDictionary* paramDict = [[params toDict] mutableCopy];
+    
+    if(self.delegate!=nil && [self.delegate getAppKey] == nil)
+    {
+        [request addValue:self.getAuthParams forHTTPHeaderField:@"Authorization"];
+    }
+    else {
+        
+        // add in the access key
+        paramDict[@"access_key"] = [self.delegate getAppKey];
+    }
+    
+    NSString *urlString = [self generateRequestUrlPrefixWithParams: paramDict];
+    
+    [request setURL: [NSURL URLWithString:urlString]];
+
     
     // set Content-Type in HTTP header
     NSString *contentType = [NSString stringWithFormat:@"multipart/form-data; boundary=%@", boundary];
@@ -42,7 +58,6 @@
     
     // setting the body of the post to the reqeust
     [request setHTTPBody:[params httpPostBodyWithObject:@{@"boundary":boundary}]];
-    NSString *urlString = [self generateRequestUrlPrefixWithParams:params.toDict];
     
     // set URL
     [request setURL: [NSURL URLWithString:urlString]];

--- a/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/ViTrackHandler.m
+++ b/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/ViTrackHandler.m
@@ -19,7 +19,9 @@
     
     NSString *urlString = [self generateRequestUrlPrefixWithParams: params.toDict andDomainUrl:@"https://track.visenze.com"];
     [request setURL: [NSURL URLWithString:urlString]];
-    [request addValue:self.getAuthParams forHTTPHeaderField:@"Authorization"];
+    
+    // this is not needed
+    //[request addValue:self.getAuthParams forHTTPHeaderField:@"Authorization"];
     
     if(self.userAgent != nil )
         [request addValue:self.userAgent forHTTPHeaderField:kVisenzeUserAgentHeader];

--- a/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/ViVersion.h
+++ b/NewExample/ViSearchExample/DemoApp/ViSearchSDK/ViSearchAPISource/ViVersion.h
@@ -10,6 +10,6 @@
 #define ViVersion_h
 
 #define kVisenzeUserAgentHeader @"X-Requested-With"
-#define kVisenzeUserAgentValue @"visearch-oc-sdk/1.1.2"
+#define kVisenzeUserAgentValue @"visearch-oc-sdk/1.2.0"
 
 #endif /* ViVersion_h */

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ViSearch is an API that provides accurate, reliable and scalable image search. V
 
 The ViSearch iOS SDK is an open source software to provide easy integration of ViSearch Search API with your iOS applications. It provides four search methods based on the ViSearch Solution APIs - Find Similar, You May Also Like, Search By Image and Search By Color. For source code and references, please visit the [Github Repository](https://github.com/visenze/visearch-sdk-ios).
 
->Current stable version: 1.1.0
+>Current stable version: 1.2.0
 
 >Supported iOS version: iOS 7.x and higher
 
@@ -64,8 +64,14 @@ You should change the access key and secret key to your own key pair before runn
 
     //TODO: insert your own application keys
     NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
-    [dict setValue:@"YOUR_ACCESS_KEY" forKey:@"access_key"];
-    [dict setValue:@"YOUR_SECRET_KEY" forKey:@"secret_key"];
+    
+    // new way of authenticate. only need app key
+    [dict setValue:@"YOUR_APP_KEY" forKey:@"app_key"];
+    
+    // old way of authentication which need access and secret key
+//    [dict setValue:@"YOUR_ACCESS_KEY" forKey:@"access_key"];
+//    [dict setValue:@"YOUR_SECRET_KEY" forKey:@"secret_key"];
+    
     [[CoreDataModel sharedInstance] insertApplication:dict];
 }
 ```
@@ -133,23 +139,35 @@ Then add it to your project
 iOS 10 now requires user permission to access camera and photo library. If your app requires these access, please add description for NSCameraUsageDescription, NSPhotoLibraryUsageDescription in the Info.plist. More details can be found [here](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW24).
 
 ## 3. Initialization
-`ViSearch` **must** be initialized with an accessKey/secretKey pair **before** it can be used.
+`ViSearch` **must** be initialized with an `appKey` or `accessKey`/`secretKey` pair **before** it can be used.
 
 ```objectivec
 #import <ViSearch/VisearchAPI.h>
 ...
 // using default ViSearch client. The client, by default,
 // connects to Visenze's server
+
+// 1. new way of init ViSearch client with only app key
+static NSString * const appKey = @"your_app_key";
+
+
+[ViSearchAPI setupAppKey:appKey];
+ViSearchClient *client = [ViSearch defaultClient];
+
+
+// 2. OR old way of init ViSearch client with access and secret key
 static NSString * const accessKey = @"your_access_key";
 static NSString * const privateKey = @"your_secret_key";
 
 [ViSearchAPI setupAccessKey:accessKey andSecretKey:secretKey];
 ViSearchClient *client = [ViSearch defaultClient];
 ...
-// or using customized client, which connects to your own server
+
+
+// OR using customized client, which connects to your own server
 static NSString * const privateKey = @"your_url";
 ViSearchClient *client = [[ViSearchClient alloc] initWithBaseUrl:url
-	accessKey:accessKey secretKey:secretKey];
+	appKey:appKey];
 ...
 ```
 
@@ -497,7 +515,7 @@ User action can be sent in this way:
 ```objectivec
 
 ViSearchClient *client = [ViSearchAPI defaultClient];
-TrackParams* params = [TrackParams createWithAccessKey:client.accessKey reqId:reqId andAction:@"click"];
+TrackParams* params = [TrackParams createWithReqId:reqId andAction:@"click" ];
 
 // ... client setup
 

--- a/ViSearch.podspec
+++ b/ViSearch.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "ViSearch"
-  s.version          = "1.1.2"
+  s.version          = "1.2.0"
   s.summary          = "A Visual Search API solution."
   s.description      = <<-DESC
                         ViSearch is a Visual Recognition Service API developed by ViSenze Pte. Ltd.
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
                        DESC
   s.homepage         = "https://github.com/visenze/visearch-sdk-ios"
   s.license          = {:type => "MIT", :file => "LICENSE"}
-  s.author           = {"Yaoxuan" => "yaoxuan@visenze.com", "Yulu" => "yulu@visenze.com"}
+  s.author           = {"Yaoxuan" => "yaoxuan@visenze.com", "Yulu" => "yulu@visenze.com", "Hung" => "hung@visenze.com"}
   s.source           = { :git => "https://github.com/visenze/visearch-sdk-ios.git", :tag => s.version.to_s }
 
   s.platform     = :ios, '7.0'

--- a/ViSearchSDK/ViSearchAPI.h
+++ b/ViSearchSDK/ViSearchAPI.h
@@ -13,6 +13,7 @@
 @interface ViSearchAPI : NSObject
 
 + (void)setupAccessKey:(NSString*) accessKey andSecretKey:(NSString*)secretKey;
++ (void)setupAppKey:(NSString *)appKey;
 + (ViSearchClient *) defaultClient;
 
 @end

--- a/ViSearchSDK/ViSearchAPI.m
+++ b/ViSearchSDK/ViSearchAPI.m
@@ -16,6 +16,10 @@
     [ViSearchClient sharedInstance].secretKey = secretKey;
 }
 
++ (void)setupAppKey:(NSString *)appKey {
+    [ViSearchClient sharedInstance].accessKey = appKey ;
+}
+
 + (ViSearchClient *)defaultClient {
     return [ViSearchClient sharedInstance];
 }

--- a/ViSearchSDK/ViSearchAPISource/TrackParams.h
+++ b/ViSearchSDK/ViSearchAPISource/TrackParams.h
@@ -17,7 +17,7 @@
 @property (nonatomic, readonly) NSString * action;
 @property (nonatomic) NSString * imName;
 @property (nonatomic, readonly) NSString * reqId;
-@property (nonatomic, readonly) NSString * cid; // set to access key
+@property (nonatomic) NSString * cid; // set to access key
 @property (nonatomic) NSString * cuid;
 
 
@@ -27,6 +27,9 @@
 
 + (TrackParams *)createWithCID:(NSString *)cid ReqId:(NSString *)reqId andAction:(NSString *)action __deprecated_msg("use createWithAccessKey:accessKey:reqId:andAction method instead");
 + (TrackParams *)createWithAccessKey:(NSString *)accessKey reqId:(NSString *)reqId andAction:(NSString *)action;
++ (TrackParams *)createWithAppKey:(NSString *)appKey reqId:(NSString *)reqId andAction:(NSString *)action;
++ (TrackParams *)createWithReqId:(NSString *)reqId andAction:(NSString *)action;
+
 
 @end
 

--- a/ViSearchSDK/ViSearchAPISource/TrackParams.m
+++ b/ViSearchSDK/ViSearchAPISource/TrackParams.m
@@ -34,6 +34,16 @@
     return self;
 }
 
+- (TrackParams *)initWithReqId:(NSString *)reqId andAction:(NSString *)action {
+    self = [super init];
+    if (self) {
+        _reqId = reqId;
+        _action = action;
+    }
+    
+    return self;
+}
+
 
 - (TrackParams *)withImName:(NSString *)imName {
     _imName = imName;
@@ -60,6 +70,37 @@
     }
 
     return [[TrackParams new] initWithCID:accessKey ReqId:reqId andAction:action];
+}
+
++ (TrackParams *)createWithAppKey:(NSString *)appKey reqId:(NSString *)reqId andAction:(NSString *)action
+{
+    if( appKey == nil || [appKey length] == 0 ){
+        [NSException raise:NSInvalidArgumentException format:@"*** -[%@ %@]: Missing parameter: appKey",  NSStringFromClass([self class]), NSStringFromSelector(_cmd)] ;
+    }
+    
+    if( reqId == nil || [reqId length] == 0 ){
+        [NSException raise:NSInvalidArgumentException format:@"*** -[%@ %@]: Missing parameter: reqId",  NSStringFromClass([self class]), NSStringFromSelector(_cmd)] ;
+    }
+    
+    if( action == nil || [action length] == 0 ){
+        [NSException raise:NSInvalidArgumentException format:@"*** -[%@ %@]: Missing parameter: action",  NSStringFromClass([self class]), NSStringFromSelector(_cmd)] ;
+    }
+    
+    return [[TrackParams new] initWithCID:appKey ReqId:reqId andAction:action];
+}
+
+// accesskey is now retrieve directly from visearch client
++ (TrackParams *)createWithReqId:(NSString *)reqId andAction:(NSString *)action
+{
+    if( reqId == nil || [reqId length] == 0 ){
+        [NSException raise:NSInvalidArgumentException format:@"*** -[%@ %@]: Missing parameter: reqId",  NSStringFromClass([self class]), NSStringFromSelector(_cmd)] ;
+    }
+    
+    if( action == nil || [action length] == 0 ){
+        [NSException raise:NSInvalidArgumentException format:@"*** -[%@ %@]: Missing parameter: action",  NSStringFromClass([self class]), NSStringFromSelector(_cmd)] ;
+    }
+    
+    return [[TrackParams new] initWithReqId:reqId andAction:action];
 }
 
 - (NSDictionary *)toDict {

--- a/ViSearchSDK/ViSearchAPISource/ViSearchBasicHandler.m
+++ b/ViSearchSDK/ViSearchAPISource/ViSearchBasicHandler.m
@@ -22,10 +22,25 @@
     else
         [request addValue:kVisenzeUserAgentValue forHTTPHeaderField:kVisenzeUserAgentHeader];
     
-    NSString *urlString = [self generateRequestUrlPrefixWithParams: params.toDict];
+    
+    
+    NSMutableDictionary* paramDict = [[params toDict] mutableCopy];
+    
+    // old way of authentication
+    if(self.delegate!=nil && [self.delegate getAppKey] == nil)
+    {
+        [request addValue:self.getAuthParams forHTTPHeaderField:@"Authorization"];
+    }
+    else {
+        // add in the access key
+        paramDict[@"access_key"] = [self.delegate getAppKey];
+    }
+    
+    NSString *urlString = [self generateRequestUrlPrefixWithParams: paramDict];
+    
     [request setURL: [NSURL URLWithString:urlString]];
-    [request addValue:self.getAuthParams forHTTPHeaderField:@"Authorization"];
-
+    
+    
     NSOperationQueue *queue = [self.delegate getOperationQ];
     
     [NSURLConnection sendAsynchronousRequest:request queue:queue

--- a/ViSearchSDK/ViSearchAPISource/ViSearchClient.h
+++ b/ViSearchSDK/ViSearchAPISource/ViSearchClient.h
@@ -19,6 +19,7 @@
 
 @property NSString *accessKey;
 @property NSString *secretKey;
+@property BOOL isAppKeyEnabled;
 @property(readonly) NSString *host;
 @property (nonatomic, assign) int timeoutInterval; // add time out interval for search client, default to 10s
 
@@ -27,6 +28,8 @@
 + (ViSearchClient *)sharedInstance;
 
 - (ViSearchClient *)initWithBaseUrl:(NSString *)baseUrl accessKey:(NSString *)accessKey secretKey:(NSString *) secretKey;
+- (ViSearchClient *)initWithBaseUrl:(NSString *)baseUrl appKey:(NSString *)appKey ;
+
 
 - (void)searchWithImageId:(SearchParams *)params
                   success:(void (^)(NSInteger statusCode, ViSearchResult *data, NSError *error)) success

--- a/ViSearchSDK/ViSearchAPISource/ViSearchClient.m
+++ b/ViSearchSDK/ViSearchAPISource/ViSearchClient.m
@@ -31,6 +31,7 @@
         sharedInstance = [[ViSearchClient alloc] init];
         sharedInstance.accessKey = @"";
         sharedInstance.secretKey = @"";
+        sharedInstance.isAppKeyEnabled = YES;
         sharedInstance.timeoutInterval = 10;
         sharedInstance.userAgent = kVisenzeUserAgentValue ;
     });
@@ -43,6 +44,21 @@
         self.host = baseUrl;
         self.accessKey = accessKey;
         self.secretKey = secretKey;
+        self.timeoutInterval = 10;
+        self.operationQ = [NSOperationQueue new];
+        self.userAgent = kVisenzeUserAgentValue ;
+        self.isAppKeyEnabled = NO;
+    }
+    
+    return self;
+}
+
+- (ViSearchClient *)initWithBaseUrl:(NSString *)baseUrl appKey:(NSString *)appKey {
+    if (self = [super init]) {
+        self.host = baseUrl;
+        self.accessKey = appKey;
+        self.secretKey = @"";
+        self.isAppKeyEnabled = YES;
         self.timeoutInterval = 10;
         self.operationQ = [NSOperationQueue new];
         self.userAgent = kVisenzeUserAgentValue ;
@@ -199,6 +215,7 @@
     handler.searchType = @"__aq.gif";
     handler.delegate = self;
     handler.userAgent = self.userAgent;
+    trackParams.cid = self.accessKey;
     
     [handler handleWithParams:trackParams completion:completion];
 }
@@ -206,6 +223,13 @@
 #pragma mark ViNetworkDelegate
 
 - (NSString *)getAccessKey {
+    return self.accessKey;
+}
+
+- (NSString *)getAppKey {
+    if (!self.isAppKeyEnabled)
+        return nil;
+    
     return self.accessKey;
 }
 

--- a/ViSearchSDK/ViSearchAPISource/ViSearchHandler.h
+++ b/ViSearchSDK/ViSearchAPISource/ViSearchHandler.h
@@ -14,6 +14,7 @@
 
 - (NSString *)getAccessKey;
 - (NSString *)getSecretKey;
+- (NSString *)getAppKey;
 - (NSString *)getHost;
 - (NSOperationQueue *)getOperationQ;
 

--- a/ViSearchSDK/ViSearchAPISource/ViSearchImageUploadHandler.m
+++ b/ViSearchSDK/ViSearchAPISource/ViSearchImageUploadHandler.m
@@ -28,7 +28,23 @@
     [request setHTTPMethod:@"POST"];
     [request setTimeoutInterval:self.timeoutInterval];
    
-    [request addValue:self.getAuthParams forHTTPHeaderField:@"Authorization"];
+    // old way of authentication
+    NSMutableDictionary* paramDict = [[params toDict] mutableCopy];
+    
+    if(self.delegate!=nil && [self.delegate getAppKey] == nil)
+    {
+        [request addValue:self.getAuthParams forHTTPHeaderField:@"Authorization"];
+    }
+    else {
+        
+        // add in the access key
+        paramDict[@"access_key"] = [self.delegate getAppKey];
+    }
+    
+    NSString *urlString = [self generateRequestUrlPrefixWithParams: paramDict];
+    
+    [request setURL: [NSURL URLWithString:urlString]];
+
     
     // set Content-Type in HTTP header
     NSString *contentType = [NSString stringWithFormat:@"multipart/form-data; boundary=%@", boundary];
@@ -42,7 +58,6 @@
     
     // setting the body of the post to the reqeust
     [request setHTTPBody:[params httpPostBodyWithObject:@{@"boundary":boundary}]];
-    NSString *urlString = [self generateRequestUrlPrefixWithParams:params.toDict];
     
     // set URL
     [request setURL: [NSURL URLWithString:urlString]];

--- a/ViSearchSDK/ViSearchAPISource/ViTrackHandler.m
+++ b/ViSearchSDK/ViSearchAPISource/ViTrackHandler.m
@@ -19,7 +19,9 @@
     
     NSString *urlString = [self generateRequestUrlPrefixWithParams: params.toDict andDomainUrl:@"https://track.visenze.com"];
     [request setURL: [NSURL URLWithString:urlString]];
-    [request addValue:self.getAuthParams forHTTPHeaderField:@"Authorization"];
+    
+    // this is not needed
+    //[request addValue:self.getAuthParams forHTTPHeaderField:@"Authorization"];
     
     if(self.userAgent != nil )
         [request addValue:self.userAgent forHTTPHeaderField:kVisenzeUserAgentHeader];

--- a/ViSearchSDK/ViSearchAPISource/ViVersion.h
+++ b/ViSearchSDK/ViSearchAPISource/ViVersion.h
@@ -10,6 +10,6 @@
 #define ViVersion_h
 
 #define kVisenzeUserAgentHeader @"X-Requested-With"
-#define kVisenzeUserAgentValue @"visearch-oc-sdk/1.1.2"
+#define kVisenzeUserAgentValue @"visearch-oc-sdk/1.2.0"
 
 #endif /* ViVersion_h */


### PR DESCRIPTION
- Add init ViSearch client with app key
- Simplify tracking init without requiring access key
- fix crash when no product type is detected during camera search